### PR TITLE
Improve configuration

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -1,8 +1,13 @@
+import os
+
 SECRET_KEY = "dev"
 GITHUB_WEBHOOK_SECRET = "dev"
 
-SENDER_EMAIL = "no-reply@lithekod.se"
-SENDER_PASSWORD = "dev"
+EMAIL_ADDRESS = "no-reply@lithekod.se"
+EMAIL_PASSWORD = "dev"
+EMAILER_PID = os.environ.get("EMAILER_PID")
+if EMAILER_PID is not None:
+    EMAILER_PID = int(EMAILER_PID)
 
 SERVER_URL = "localhost:5000"
 

--- a/db.py
+++ b/db.py
@@ -1,7 +1,5 @@
 import sqlite3
 
-from config import ACTIONS
-
 from flask import g, current_app
 
 def get_db():
@@ -37,15 +35,14 @@ def modify_db(query, args):
     conn.commit()
 
 
-def init_db(app):
+def init_db():
     """
     Construct the tables in the database.
     Call this function once when setting up the server.
     """
-    with app.app_context():
-        db = get_db()
-        with app.open_resource("schema.sql", mode="r") as f:
-            db.cursor().executescript(f.read())
+    db = get_db()
+    with current_app.open_resource("schema.sql", mode="r") as f:
+        db.cursor().executescript(f.read())
 
-        db.executemany("INSERT INTO action VALUES (?)", [(i,) for i in ACTIONS])
-        db.commit()
+    db.executemany("INSERT INTO action VALUES (?)", [(i,) for i in current_app.config["ACTIONS"]])
+    db.commit()

--- a/run
+++ b/run
@@ -5,8 +5,7 @@ if [[ ! -d logs ]]; then
 fi
 
 python3 emailer.py server &
-
-echo "$!" > /tmp/emailerpid
+export EMAILER_PID=$!
 
 gunicorn \
     --bind localhost:8000 \

--- a/test.py
+++ b/test.py
@@ -16,7 +16,8 @@ def reset_db():
     except OSError:
         pass
 
-    init_db(app)
+    with app.app_context():
+        init_db()
 
 
 def app_get(path, get_data=False):


### PR DESCRIPTION
Before it was kind of clunky to change anything about the database, and
there always needed to be a file in the repo with the settings. Now it
is possible to override the default settings by doing `export
DATABASE_CONFIG=/path/to/config.py`. This change also removes the need
for a temporary file containing the PID of the emailer.

Additionally, it should now be easy to have separate configurations when
testing, debugging, and so on. These settings can be added to the config
folder.
